### PR TITLE
3/create new sprint

### DIFF
--- a/gnome-project/backtrack/models.py
+++ b/gnome-project/backtrack/models.py
@@ -95,12 +95,19 @@ class ProductBacklog(models.Model):
     def __str__(self):
         return self.name
 
+    def save(self, *args, **kwargs):
+        is_new = True if not self.id else False
+        super(ProductBacklog, self).save(*args, **kwargs)
+        if is_new:
+            sprint_backlog = SprintBacklog(name=self.name+" sprint0", productBacklogID=self)
+            sprint_backlog.save()
+
     def pbiList(self):
         return ProductBacklogItem.objects.filter(productBacklogID=self.id).order_by('priority')
 
 class SprintBacklog(models.Model):
     name = models.CharField(max_length=200)
-    status = models.CharField(max_length=200, default=SprintStatus.CURRENT.value, choices=SprintStatus.choices())
+    status = models.CharField(max_length=200, default=SprintStatus.NOTYETSTARTED.value, choices=SprintStatus.choices())
     productBacklogID = models.ForeignKey(ProductBacklog, on_delete=models.CASCADE)
 
     def __str__(self):
@@ -131,7 +138,7 @@ class SprintBacklog(models.Model):
 class ProductBacklogItem(models.Model):
     name = models.CharField(max_length=200)
     description = models.CharField(max_length=500)
-    pointEstimate = models.IntegerField(blank=True, null=True)
+    pointEstimate = models.IntegerField(blank=True, null=True, default=1)
     productBacklogID = models.ForeignKey(ProductBacklog, on_delete=models.CASCADE)
     sprintBacklogID = models.ForeignKey(SprintBacklog, on_delete=models.CASCADE, blank=True, null=True)
     status = models.CharField(max_length=50, default=PBIStatus.NOT_YET_STARTED.value, choices=PBIStatus.choices())

--- a/gnome-project/backtrack/models.py
+++ b/gnome-project/backtrack/models.py
@@ -24,6 +24,7 @@ class ProjectStatus(Enum):
 class SprintStatus(Enum):
     CURRENT = "current"
     COMPLETE = "complete"
+    NOTYETSTARTED = "not yet started"
 
     @classmethod
     def choices(cls):
@@ -104,21 +105,21 @@ class SprintBacklog(models.Model):
 
     def __str__(self):
         return self.name
-    
+
 
     def pbiList(self):
         return ProductBacklogItem.objects.filter(sprintBacklogID=self.id).order_by('priority')
-   
+
     @property
     def sprint_cummulative_effort_hours(self):
-        x = 0 
+        x = 0
         for PBI in self.pbiList():
             x += PBI.tasks_cummulative_effort_hours
         return x
 
     @property
     def sprint_actual_effort_hours(self):
-        x = 0 
+        x = 0
         for PBI in self.pbiList():
             x += PBI.tasks_actual_effort_hours
         return x
@@ -150,10 +151,10 @@ class ProductBacklogItem(models.Model):
 
     def tasks_not_yet_started(self):
         return Task.objects.filter(pbi=self.pk, status=TaskStatus.NOT_YET_STARTED.value)
-    
+
     @property
     def tasks_cummulative_effort_hours(self):
-        x = 0 
+        x = 0
         for Task in self.tasks():
             if (type(Task.estimatedEffortHours) is float):
                 x += Task.estimatedEffortHours
@@ -161,7 +162,7 @@ class ProductBacklogItem(models.Model):
 
     @property
     def tasks_actual_effort_hours(self):
-        x = 0 
+        x = 0
         for Task in self.tasks():
             if (type(Task.actualEffortHours) is float):
                 x += Task.actualEffortHours
@@ -182,4 +183,3 @@ class Task(models.Model):
         return self.name
     def tasks_estimated_effort_hours(self):
         return self.estimatedEffortHours
-

--- a/gnome-project/backtrack/urls.py
+++ b/gnome-project/backtrack/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [path('projects', views.ViewAllProjects.as_view(), name='projects'
                path('projects/<int:project>/<int:productBacklog>/create-new-pbi', views.CreateNewPBIView.as_view(), name='newPBI'),
                path('projects/<int:project>/<int:SprintBacklog>/<int:pbi>/create-new-task', views.CreateNewTaskView.as_view(), name='newTASK'),
                path('projects/<int:project>/<int:productBacklog>/create-new-sprint', views.CreateNewSprintView.as_view(), name='newSprint'),
+               path('projects/product-backlog/sprint-backlog/<int:pk>', views.EditSprintbacklog.as_view(), name='editSprintBacklog'),
 
                ]

--- a/gnome-project/backtrack/views.py
+++ b/gnome-project/backtrack/views.py
@@ -52,6 +52,20 @@ class EditPBI(UpdateView):
         return reverse('project', args=(project.id,))
 
 
+class EditSprintbacklog(UpdateView):
+    template_name = "sprint.html"
+
+    model = SprintBacklog
+    slug_field = "sprint"
+    fields = ['name', 'status']
+
+    def get_success_url(self):
+        sprint_ID = self.object.id
+        sprint = SprintBacklog.objects.get(id=sprint_ID)
+        project = Project.objects.get(id=sprint.productBacklogID.project_id)
+        return reverse('project', args=(project.id,))
+
+
 class DeleteTask(DeleteView):
     template_name = "task_confirm_delete.html"
     model = Task

--- a/gnome-project/backtrack/views.py
+++ b/gnome-project/backtrack/views.py
@@ -125,17 +125,19 @@ class ViewProject(TemplateView):
 
             if len(sprint_list_current) == 0:
                 print("create a new sprint")
-            
+
             sprint_list_done = sprint_backlogs.filter(status=SprintStatus.COMPLETE.value)
+            sprint_list_not_yet_started = sprint_backlogs.filter(status=SprintStatus.NOTYETSTARTED.value)
 
             context['sprint_list_done'] = sprint_list_done
+            context['sprint_list_not_yet_started'] = sprint_list_not_yet_started
 
             pbiList = product_backlog_list[0].pbiList()
             completedPbiList = pbiList.filter(status=PBIStatus.COMPLETE.value)
 
             cumulativePoints = []
             cumulativeCounter = 0
-            
+
             for pbi in pbiList:
                 if (pbi.status != PBIStatus.COMPLETE.value):
                     cumulativeCounter += pbi.pointEstimate
@@ -206,7 +208,7 @@ class CreateNewSprintView(CreateView):
         productBacklog = ProductBacklog.objects.get(id=productBacklogID.id)
         project = Project.objects.get(id=productBacklog.project.id)
         return reverse('project', args=(project.id,))
-    
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         productBacklogID = self.kwargs['productBacklog']

--- a/gnome-project/templates/project.html
+++ b/gnome-project/templates/project.html
@@ -14,7 +14,7 @@
 
     <!--Create New Sprint -->
 
-    <form action="{{project.id}}/create-new-sprint">
+    <form action="{{project.id}}/{{product_backlog.id}}/create-new-sprint">
         <button type="submit"
             class="btn btn-default">
             Create New Sprint
@@ -69,7 +69,7 @@
                         <td></td>
                         <td>
                             {% for complete in pbi.tasks_complete %}
-                            <form action="product-backlog/{{pbi.id}}/{{not_yet_started.id}}">
+                            <form action="product-backlog/{{pbi.id}}/{{complete.id}}">
                                 <button type="submit"
                                         class="btn btn-default">
                                     {{ complete.name }}
@@ -126,6 +126,12 @@
                 <li>
                     Sprint {{ sprint.name }} Backlog
                 </li>
+                <form action="product-backlog/sprint-backlog/{{sprint.id}}">
+                    <button type="submit"
+                            class="btn btn-default">
+                                edit sprint status
+                    </button>
+                </form>
                 <br>
                 {% if sprint.pbiList %}
                 <table>
@@ -141,13 +147,38 @@
                     </tr>
                     {% for pbi in sprint.pbiList %}
                     <tr>
-                        <td> {{ pbi.name }} </td>
+                        <td> {{ pbi.name }}
+                            <form action="{{project.id}}/{{sprint_current.id}}/{{pbi.id}}/create-new-task">
+                                <button type="submit"
+                                        class="btn btn-default">
+                                Add Task
+                                </button>
+                            </form>
+                        </td>
                         <td> {{ pbi.description }} </td>
-                        <td></td>
-                        <td></td>
+                        <td>
+                            {% for not_yet_started in pbi.tasks_not_yet_started %}
+                            <form action="product-backlog/{{pbi.id}}/{{not_yet_started.id}}">
+                                <button type="submit"
+                                        class="btn btn-default">
+                                    {{ not_yet_started.name }}
+                                </button>
+                            </form>
+                        {% endfor %}
+                        </td>
+                        <td>
+                            {% for in_progress in pbi.tasks_in_progress %}
+                            <form action="product-backlog/{{pbi.id}}/{{in_progress.id}}">
+                                <button type="submit"
+                                        class="btn btn-default">
+                                    {{ in_progress.name }}
+                                </button>
+                            </form>
+                            {% endfor %}
+                        </td>
                         <td>
                             {% for complete in pbi.tasks_complete %}
-                            <form action="product-backlog/{{pbi.id}}/{{not_yet_started.id}}">
+                            <form action="product-backlog/{{pbi.id}}/{{complete.id}}">
                                 <button type="submit"
                                         class="btn btn-default">
                                     {{ complete.name }}
@@ -187,6 +218,14 @@
             {% else %}
 
             Current Sprint Backlog {{ sprint_current.name }} &nbsp;&nbsp;&nbsp;&nbsp; <font size="-1.5"> Total Story Points: {{ sprint_current.sprint_cummulative_effort_hours}}</font>&nbsp;&nbsp;&nbsp;&nbsp; <font size="-1.5"> Total Effort Hours: {{ sprint_current.sprint_actual_effort_hours}}</font>&nbsp;&nbsp;&nbsp;&nbsp; <font size="-1.5"> Total Work Remaining: {{ sprint_current.sprint_work_remaining}}</font>
+
+            <form action="product-backlog/sprint-backlog/{{sprint_current.id}}">
+                <button type="submit"
+                        class="btn btn-default">
+                            edit sprint status
+                </button>
+            </form>
+
             {% if sprint_current.pbiList %}
             <table>
                 <tr>

--- a/gnome-project/templates/project.html
+++ b/gnome-project/templates/project.html
@@ -11,6 +11,16 @@
         <style></style>
     </head>
     <body>
+
+    <!--Create New Sprint -->
+
+    <form action="{{project.id}}/create-new-sprint">
+        <button type="submit"
+            class="btn btn-default">
+            Create New Sprint
+        </button>
+    </form>
+
     <!--Completed sprints-->
         <p> Completed Sprint Backlogs
             <button type="button"
@@ -87,6 +97,84 @@
         </div>
 
     <hr>
+
+
+    <!--Not yet started sprints-->
+        <p> Not Yet Started Sprint Backlogs
+            <button type="button"
+                    id="showHideButtonNotStarted"
+                    onclick="showHideNoStartedSprint()"
+                    class="btn btn-default">
+                Show
+            </button>
+        </p>
+        <script>
+        function showHideNoStartedSprint() {
+            if (document.getElementById("showHideButtonNotStarted").innerHTML != "Hide") {
+                document.getElementById("showHideButtonNotStarted").innerHTML = "Hide";
+                document.getElementById("notStartedYetSprints").style.display = "block";
+            }
+            else {
+                document.getElementById("showHideButtonNotStarted").innerHTML = "Show";
+                document.getElementById("notStartedYetSprints").style.display = "none";
+            }
+        }
+        </script>
+        <div id="notStartedYetSprints" style="display: none;">
+        <!-- not yet started sprints code-->
+            <ul> {% for sprint in sprint_list_not_yet_started %}
+                <li>
+                    Sprint {{ sprint.name }} Backlog
+                </li>
+                <br>
+                {% if sprint.pbiList %}
+                <table>
+                    <tr>
+                        <th>Sprint Backlog Item Name</th>
+                        <th>Description</th>
+                        <th>Tasks Not Yet Started</th>
+                        <th>Tasks In Progress</th>
+                        <th>Tasks Completed</th>
+                        <th>Estimated Effort Hours</th>
+                        <th>Actual Effort Hours</th>
+                        <th>Work Remaining</th>
+                    </tr>
+                    {% for pbi in sprint.pbiList %}
+                    <tr>
+                        <td> {{ pbi.name }} </td>
+                        <td> {{ pbi.description }} </td>
+                        <td></td>
+                        <td></td>
+                        <td>
+                            {% for complete in pbi.tasks_complete %}
+                            <form action="product-backlog/{{pbi.id}}/{{not_yet_started.id}}">
+                                <button type="submit"
+                                        class="btn btn-default">
+                                    {{ complete.name }}
+                                </button>
+                            </form>
+                            {% endfor %}
+                        </td>
+                        <td> {{ pbi.tasks_cummulative_effort_hours}} </td>
+                        <td> {{ pbi.tasks_actual_effort_hours}} </td>
+                        <td> {{ pbi.tasks_work_remaining}} </td>
+                    </tr>
+                    {% endfor %}
+                </table>
+                {% else %}
+                <div>
+                    This sprint is empty.
+                </div>
+                {% endif %}
+                {% empty %}
+                <div>
+                    No sprints not started yet.
+                </div>
+                {% endfor %}
+            </ul>
+        </div>
+
+<hr>
 
         <!-- Current Sprint-->
         <p> {% if sprint_current == None %}

--- a/gnome-project/templates/sprint.html
+++ b/gnome-project/templates/sprint.html
@@ -1,0 +1,22 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="{% static 'css/template.css' %}">
+        <title>Edit Sprint Backlog</title>
+        <div class="page-header">
+            <h1 style="text-align: center;"><img width="144" src="{% static 'backtrack.svg' %}" alt="Backtrack"/></h1>
+        </div>
+        <style></style>
+    </head>
+    <body>
+        <form method="post">{% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit"
+                    value="update"
+                    class="btn btn-default">
+                Update
+            </button>
+        </form>
+    </body>
+</html>


### PR DESCRIPTION
1) minor change on the NotYetStarted sprint : everything is displayed now 
2) during the demo, the completed task couldn't be shown/edit -> fixed
3) the add/create PBI button for product blacklog works
4) create a new sprint works (*)

(*) what happend before is that the way we coded (urls...) we needed a product backlog AND a sprint backlog. So we also needed a default sprint backlog when we create a project (really had to if we didn't want to modify all our code)

:) 